### PR TITLE
add missing foreign key index, correct constraint name

### DIFF
--- a/customer_orders/co_constraints.sql
+++ b/customer_orders/co_constraints.sql
@@ -62,5 +62,5 @@ alter table inventory add constraint inventory_store_product_u unique (store_id,
 alter table inventory add constraint inventory_store_id_fk 
    foreign key (store_id) references stores (store_id);
 
-alter table inventory add constraint shipments_product_id_fk 
+alter table inventory add constraint inventory_product_id_fk 
    foreign key (product_id) references products (product_id);

--- a/customer_orders/co_tables.sql
+++ b/customer_orders/co_tables.sql
@@ -74,4 +74,5 @@ create index orders_customer_id_i on orders ( customer_id );
 create index orders_store_id_i on orders ( store_id );
 create index shipments_store_id_i on shipments ( store_id );
 create index shipments_customer_id_i on shipments ( customer_id );
+create index order_items_shipment_id_i on order_items ( shipment_id );
 create index inventory_product_id_i on inventory ( product_id );


### PR DESCRIPTION
Missing foreign key index:

- file: [customer_orders/co_tables.sql](https://github.com/oracle/db-sample-schemas/blob/master/customer_orders/co_tables.sql)
- action: add code `create index order_items_shipment_id_i on order_items (shipment_id)`

Wrong constraint name:

- file: [customer_orders/co_constraints.sql](https://github.com/oracle/db-sample-schemas/blob/master/customer_orders/co_constraints.sql)
- code (line 65): `alter table inventory add constraint shipments_product_id_fk foreign key (product_id) references products (product_id);`
- action: replace `shipments_product_id_fk` with `inventory_product_id_fk`